### PR TITLE
Add JaCoCo and coverage threshold (70%)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,5 +31,11 @@ jobs:
           cache: maven
       - name: Verify with Maven
         run: cd HelloWorldFunction && ./mvnw -B verify --file pom.xml
+      - name: Upload JaCoCo report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: HelloWorldFunction/target/site/jacoco
       - name: Build with Maven
         run: cd HelloWorldFunction && ./mvnw -B package --file pom.xml

--- a/HelloWorldFunction/pom.xml
+++ b/HelloWorldFunction/pom.xml
@@ -22,6 +22,7 @@
     <google-java-format.version>1.28.0</google-java-format.version>
     <checkstyle.plugin.version>3.3.1</checkstyle.plugin.version>
     <checkstyle.version>10.16.0</checkstyle.version>
+    <jacoco.version>0.8.12</jacoco.version>
   </properties>
 
   <dependencyManagement>
@@ -172,6 +173,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire-plugin.version}</version>
         <configuration>
+          <argLine>${argLine}</argLine>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
@@ -191,6 +193,7 @@
           </execution>
         </executions>
         <configuration>
+          <argLine>${argLine}</argLine>
           <systemPropertyVariables>
             <native.image.path>${project.build.directory}/${project.build.finalName}-runner
             </native.image.path>
@@ -198,6 +201,47 @@
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.version}</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>jacoco-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.70</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <!--
       <plugin>


### PR DESCRIPTION
目的: JaCoCo を導入し、レポート生成と最小カバレッジしきい値 70% を設定します。\n\n変更点:\n- pom.xml: jacoco-maven-plugin を追加し verify フェーズで report, check を実行。\n- surefire/failsafe: argLine 連携で JaCoCo エージェントを適用。\n- CI(build.yaml): JaCoCo レポートを actions/upload-artifact で保存。\n\n動作確認:\n- ローカルで  実行し、 target/site/jacoco にレポート生成を確認。\n- しきい値未達の場合  で verify 失敗。\n\n関連: closes #58